### PR TITLE
Small macro fix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AtomsCalculators"
 uuid = "a3e0e189-c65a-42c1-833c-339540406eb1"
 authors = ["JuliaMolSim contributors"]
-version = "0.1.0"
+version = "0.1.1-DEV"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"

--- a/docs/src/interface-definition.md
+++ b/docs/src/interface-definition.md
@@ -61,7 +61,7 @@ using Unitful
 struct MyType
 end
 
-AtomsCalculators.@generate_interface function AtomsCalculators.potential_energy(system, calculator::Main.MyType; kwargs...)
+AtomsCalculators.@generate_interface function AtomsCalculators.potential_energy(system, calculator::MyType; kwargs...)
     # we can ignore kwargs... or use them to tune the calculation
     # or give extra information like pairlist
 
@@ -70,16 +70,10 @@ AtomsCalculators.@generate_interface function AtomsCalculators.potential_energy(
 end
 ```
 
-!!! note "Type definition under @generate_complement macro"
-    You need to use explicit definition of type when using
-    `@generate_interface` macro. `Main.MyType` is fine `MyType` is not!
-
-    You also need to define the type before the macro call.
-
 Completely equivalent implementation is
 
 ```julia
-AtomsCalculators.@generate_interface function AtomsCalculators.calculate(::AtomsCalculators.Energy, system, calculator::Main.MyType; kwargs...)
+AtomsCalculators.@generate_interface function AtomsCalculators.calculate(::AtomsCalculators.Energy, system, calculator::MyType; kwargs...)
     # we can ignore kwargs... or use them to tune the calculation
     # or give extra information like pairlist
 
@@ -91,7 +85,7 @@ end
 Example `virial` implementation
 
 ```julia
-AtomsCalculators.@generate_interface function AtomsCalculators.virial(system, calculator::Main.MyType; kwargs...)
+AtomsCalculators.@generate_interface function AtomsCalculators.virial(system, calculator::MyType; kwargs...)
     # we can ignore kwargs... or use them to tune the calculation
     # or give extra information like pairlist
 
@@ -103,7 +97,7 @@ end
 Equivalent implementation is
 
 ```julia
-AtomsCalculators.@generate_interface function AtomsCalculators.calculate(::AtomsCalculators.Virial, system, calculator::Main.MyType; kwargs...)
+AtomsCalculators.@generate_interface function AtomsCalculators.calculate(::AtomsCalculators.Virial, system, calculator::MyType; kwargs...)
     # we can ignore kwargs... or use them to tune the calculation
     # or give extra information like pairlist
 
@@ -117,7 +111,7 @@ end
 Basic example
 
 ```julia
-AtomsCalculators.@generate_interface function AtomsCalculators.forces(system, calculator::Main.MyType; kwargs...)
+AtomsCalculators.@generate_interface function AtomsCalculators.forces(system, calculator::MyType; kwargs...)
     # we can ignore kwargs... or use them to tune the calculation
     # or give extra information like pairlist
 
@@ -135,7 +129,7 @@ Same way `AtomsCalculators.promote_force_type(system, calculator)` creates a for
 Alternatively the definition could have been done with
 
 ```julia
-AtomsCalculators.@generate_interface function AtomsCalculators.calculate(::AtomsCalculators.Forces, system, calculator::Main.MyType; kwargs...)
+AtomsCalculators.@generate_interface function AtomsCalculators.calculate(::AtomsCalculators.Forces, system, calculator::MyType; kwargs...)
     # we can ignore kwargs... or use them to tune the calculation
     # or give extra information like pairlist
 
@@ -150,7 +144,7 @@ or with non-allocating forces
 struct MyOtherType
 end
 
-AtomsCalculators.@generate_interface function AtomsCalculators.forces!(f::AbstractVector, system, calculator::Main.MyOtherType; kwargs...)
+AtomsCalculators.@generate_interface function AtomsCalculators.forces!(f::AbstractVector, system, calculator::MyOtherType; kwargs...)
     @assert length(f) == length(system)
     # we can ignore kwargs... or use them to tune the calculation
     # or give extra information like pairlist

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -14,7 +14,7 @@ to define one of the interface methods for a given type of calculation
 Generate `forces!` and `calculate(AtomsCalculators.Forces(), ...)` calls from `forces` definition
 
 ```julia
-AtomsCalculators.@generate_interface function AtomsCalculators.forces(system, calculator::Main.MyType; kwargs...)
+AtomsCalculators.@generate_interface function AtomsCalculators.forces(system, calculator::MyType; kwargs...)
     #definition here
 end
 ```
@@ -22,7 +22,7 @@ end
 Generate `forces` and  `calculate(AtomsCalculators.Forces(), ...)` calls from `forces!` definition
 
 ```julia
-AtomsCalculators.@generate_interface function AtomsCalculators.forces!(f::AbstractVector, system, calculator::Main.MyOtherType; kwargs...)
+AtomsCalculators.@generate_interface function AtomsCalculators.forces!(f::AbstractVector, system, calculator::MyOtherType; kwargs...)
     #definition here
 end
 ```
@@ -30,16 +30,10 @@ end
 Generate `AtomsCalculators.potential_energy` call from `AtomsCalculators.calculate` call.
 
 ```julia
-AtomsCalculators.@generate_interface function AtomsCalculators.calculate(::AtomsCalculators.Energy(), system, calculator::Main.MyType; kwargs...)
+AtomsCalculators.@generate_interface function AtomsCalculators.calculate(::AtomsCalculators.Energy(), system, calculator::MyType; kwargs...)
     #definition here
 end
 ```
-
-# Note
-
-When using this macro, you need to define your calculator type completely - `MyPkg.MyType` is fine
-but `MyType` is not!
-
 """
 macro generate_interface(expr)
     type = nothing
@@ -89,6 +83,7 @@ macro generate_interface(expr)
         $expr
         $q
     end
+    # We need to excape macro hygiene to get correct type information
     return esc(ex)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -89,7 +89,7 @@ macro generate_interface(expr)
         $expr
         $q
     end
-    return ex
+    return esc(ex)
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,7 @@ using AtomsCalculators.AtomsCalculatorsTesting
     struct MyTypeC
     end
 
-    AtomsCalculators.@generate_interface function AtomsCalculators.potential_energy(system, calculator::Main.MyType; kwargs...)
+    AtomsCalculators.@generate_interface function AtomsCalculators.potential_energy(system, calculator::MyType; kwargs...)
         # we can ignore kwargs... or use them to tune the calculation
         # or give extra information like pairlist
     
@@ -24,7 +24,7 @@ using AtomsCalculators.AtomsCalculatorsTesting
         return 0.0u"eV"
     end
     
-    AtomsCalculators.@generate_interface function AtomsCalculators.virial(system, calculator::Main.MyType; kwargs...)
+    AtomsCalculators.@generate_interface function AtomsCalculators.virial(system, calculator::MyType; kwargs...)
         # we can ignore kwargs... or use them to tune the calculation
         # or give extra information like pairlist
     
@@ -33,7 +33,7 @@ using AtomsCalculators.AtomsCalculatorsTesting
     end
     
     
-    AtomsCalculators.@generate_interface function AtomsCalculators.forces(system, calculator::Main.MyType; kwargs...)
+    AtomsCalculators.@generate_interface function AtomsCalculators.forces(system, calculator::MyType; kwargs...)
         # we can ignore kwargs... or use them to tune the calculation
         # or give extra information like pairlist
     
@@ -41,7 +41,7 @@ using AtomsCalculators.AtomsCalculatorsTesting
         return AtomsCalculators.zero_forces(system, calculator)
     end
     
-    AtomsCalculators.@generate_interface function AtomsCalculators.forces!(f::AbstractVector, system, calculator::Main.MyOtherType; kwargs...)
+    AtomsCalculators.@generate_interface function AtomsCalculators.forces!(f::AbstractVector, system, calculator::MyOtherType; kwargs...)
         @assert length(f) == length(system)
         # we can ignore kwargs... or use them to tune the calculation
         # or give extra information like pairlist
@@ -57,7 +57,7 @@ using AtomsCalculators.AtomsCalculatorsTesting
     AtomsCalculators.@generate_interface function AtomsCalculators.calculate(
         ::AtomsCalculators.Energy, 
         system, 
-        calculator::Main.MyTypeC; 
+        calculator::MyTypeC; 
         kwargs...
     )
         # we can ignore kwargs... or use them to tune the calculation
@@ -70,7 +70,7 @@ using AtomsCalculators.AtomsCalculatorsTesting
     AtomsCalculators.@generate_interface function AtomsCalculators.calculate(
         ::AtomsCalculators.Virial, 
         system, 
-        calculator::Main.MyTypeC; 
+        calculator::MyTypeC; 
         kwargs...
     )
         # we can ignore kwargs... or use them to tune the calculation
@@ -84,7 +84,7 @@ using AtomsCalculators.AtomsCalculatorsTesting
     AtomsCalculators.@generate_interface function AtomsCalculators.calculate(
         ::AtomsCalculators.Forces, 
         system, 
-        calculator::Main.MyTypeC; 
+        calculator::MyTypeC; 
         kwargs...
     )
         # we can ignore kwargs... or use them to tune the calculation


### PR DESCRIPTION
The initial release has an issue with macro not working in most cases...

The issue was macro hygiene related and this PR will fix it.

Basically we needed `esc` call for macro output and everything works after it. This has an additional benefit for relaxing input type definitions, so I updated the docs accordingly.