### PR TITLE
Add compat entry for Test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 [compat]
 AtomsBase = "0.3"
 StaticArrays = "1"
+Test = "1"
 Unitful = "1"
 julia = "1.6"
 


### PR DESCRIPTION
Registering new version is [stuck](https://github.com/JuliaRegistries/General/pull/94447) because `Test` does not have compat entry, as required by the new [speck](https://discourse.julialang.org/t/psa-compat-requirements-in-the-general-registry-are-changing/104958). 