### PR TITLE
Added AbstractCalculator abstract type.

### DIFF
--- a/src/AtomsCalculators.jl
+++ b/src/AtomsCalculators.jl
@@ -1,5 +1,7 @@
 module AtomsCalculators
 
+export AbstractCalculator
+
 
 using AtomsBase
 using StaticArrays

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,4 +1,6 @@
 
+abstract type AbstractCalculator end
+
 struct Energy end
 struct Forces end
 struct Virial end


### PR DESCRIPTION
This PR adds an AbstractCalculator abstract type to the AtomsCalculators interface. 

(this is part of the effort to develop a geometry optimization package for the JuliaMolSim ecosystem [https://github.com/CedricTravelletti/GeomOpt.jl](https://github.com/CedricTravelletti/GeomOpt.jl)).