### PR TITLE
Add Hessian calculation support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AtomsCalculators"
 uuid = "a3e0e189-c65a-42c1-833c-339540406eb1"
 authors = ["JuliaMolSim contributors"]
-version = "0.1.1"
+version = "0.1.2-DEV"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2,6 +2,7 @@
 struct Energy end
 struct Forces end
 struct Virial end
+struct Hessian end
 
 function potential_energy end 
 
@@ -12,6 +13,8 @@ function forces! end
 function virial end 
 
 function calculate end
+
+function hessian end
 
 promote_force_type(::Any, ::Any) = SVector(1., 1., 1.) * u"eV/Å" |> typeof
 

--- a/src/submodules/AtomsCalculatorsTesting.jl
+++ b/src/submodules/AtomsCalculatorsTesting.jl
@@ -7,6 +7,7 @@ using Test
 export test_potential_energy
 export test_forces
 export test_virial
+export test_hessian
 
 
 """
@@ -117,6 +118,25 @@ function test_virial(sys, calculator; kwargs...)
     end
 end
 
+
+
+function test_hessian(sys, calculator; kwargs...)
+    @testset "Test hessian for $(typeof(calculator))" begin
+        l = length(sys) * length(position(sys, 1))
+        h = AtomsCalculators.hessian(sys, calculator; kwargs...)
+        @test isa(h, AbstractArray)
+        @test eltype(h) <: Number
+        @test size(h) == (l,l)
+        h_cpu_array = Array(h)
+        @test dimension(h_cpu_array[1,1]) == dimension(u"J/m^2")
+        h2 = AtomsCalculators.hessian(sys, calculator; dummy_kword235887=2, kwargs...)
+        @test all( h .≈ h2 )
+        hc = AtomsCalculators.calculate(AtomsCalculators.Hessian(), sys, calculator; kwargs...)
+        @test isa(hc, NamedTuple)
+        @test haskey(hc, :hessian)
+        @test all( h .≈ hc[:hessian] )
+    end
+end
 
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,16 @@ using AtomsCalculators.AtomsCalculatorsTesting
         # add your own definition
         return AtomsCalculators.zero_forces(system, calculator)
     end
+
+    AtomsCalculators.@generate_interface function AtomsCalculators.hessian(system, calculator::MyType; kwargs...)
+        # we can ignore kwargs... or use them to tune the calculation
+        # or give extra information like pairlist
+    
+        # add your own definition
+        l = length(system) * length(position(system, 1))
+        return zeros(l,l) * (u"eV" / u"Å"^2)
+    end
+
     
     AtomsCalculators.@generate_interface function AtomsCalculators.forces!(f::AbstractVector, system, calculator::MyOtherType; kwargs...)
         @assert length(f) == length(system)
@@ -95,6 +105,21 @@ using AtomsCalculators.AtomsCalculatorsTesting
         return ( forces = f, )
     end
 
+    AtomsCalculators.@generate_interface function AtomsCalculators.calculate(
+        ::AtomsCalculators.Hessian, 
+        system, 
+        calculator::MyTypeC; 
+        kwargs...
+    )
+        # we can ignore kwargs... or use them to tune the calculation
+        # or give extra information like pairlist
+    
+        # add your own definition
+        l = length(system) * length(position(system, 1))
+        h = zeros(l,l) * (u"eV" / u"Å"^2)
+        return ( hessian = h, )
+    end
+
     hydrogen = isolated_system([
     :H => [0, 0, 0.]u"Å",
     :H => [0, 0, 1.]u"Å"
@@ -103,11 +128,13 @@ using AtomsCalculators.AtomsCalculatorsTesting
     test_potential_energy(hydrogen, MyType())
     test_forces(hydrogen, MyType())
     test_virial(hydrogen, MyType())
+    test_hessian(hydrogen, MyType())
     test_forces(hydrogen, MyOtherType())
     
     test_potential_energy(hydrogen, MyTypeC())
     test_forces(hydrogen, MyTypeC())
     test_virial(hydrogen, MyTypeC())
+    test_hessian(hydrogen, MyTypeC())
 
     efv = AtomsCalculators.energy_forces_virial(hydrogen, MyType())
     @test haskey(efv, :energy)


### PR DESCRIPTION
Hessian calculation is defined the same way as other calculation types

```julia
AtomsCalculators.hessian(system, calculator)
# or
AtomsCalculators.calculate(AtomsCalculators.Hessian(), system, calculator)
``` 

`@generate_interface` macro can be used to help define the calculator interface. Also, `test_hessian` function has been added to help testing the interface.

So, basically this is a very simple addition of Hessian to the interface.

@cortner, @mfherbst, @rkurchin, @jgreener64 