### PR TITLE
Testing improvements and a clarification to the interface

### DIFF
--- a/docs/src/interface-definition.md
+++ b/docs/src/interface-definition.md
@@ -199,11 +199,13 @@ The type of the output can be [NamedTuple](https://docs.julialang.org/en/v1/base
 
 ## Testing Function Calls
 
-We have implemented function calls to help you testing the API. There is one call for each type of calls 
+We have implemented function calls to help you testing the API. There is one call for each type of calls
 
 - `test_potential_energy` to test potential_energy call
 - `test_forces` to test both allocating and non-allocating force calls
 - `test_virial` to test virial call
+- `test_energy_forces` to test both potential energy and force calls
+- `test_energy_forces_virial` to test everything 
 
 To get these access to these functions you need to call
 
@@ -220,14 +222,20 @@ using AtomsCalculators.AtomsCalculatorsTesting
 hydrogen = isolated_system([
     :H => [0, 0, 0.]u"Å",
     :H => [0, 0, 1.]u"Å"
-])
-
-test_potential_energy(hydrogen, MyType())
+])test_energy_forces(sys, calculator; rtol=1e8, kwargs...)nergy(hydrogen, MyType())
 test_forces(hydrogen, MyType())
 test_virial(hydrogen, MyType())
 
 test_forces(hydrogen, MyOtherType()) # this works
 test_virial(hydrogen, MyOtherType()) # this will fail
+
+# If you have energy and forces implemented use this over others
+test_energy_forces(hydrogen, MyType())
+
+# If you have energy, forces and virial implemented use this others
+test_energy_forces_virial(hydrogen, MyType())
 ```
 
 *It is recommended that you use the test functions to test that your implementation supports the API fully!*
+
+

--- a/docs/src/interface-definition.md
+++ b/docs/src/interface-definition.md
@@ -151,7 +151,8 @@ AtomsCalculators.@generate_interface function AtomsCalculators.forces!(f::Abstra
 
     # add your own definition
     for i in eachindex(f)
-        f[i] = zero(AtomsCalculators.promote_force_type(system, calculator))
+        # forces! adds to the force array
+        f[i] += zero(AtomsCalculators.promote_force_type(system, calculator))
     end
 
     return f

--- a/docs/src/interface-definition.md
+++ b/docs/src/interface-definition.md
@@ -43,7 +43,6 @@ Outputs for the functions need to have following properties
 - Virial is a square matrix (3x3 in 3D) that has units of force times length or energy
 - Calculate methods return a [NamedTuple](https://docs.julialang.org/en/v1/base/base/#Core.NamedTuple) that uses keys `:energy`, `:forces` and `:virial` to identify the results, which have the types defined above
 
-
 ## Implementing the interface
 
 You can either implement both of the calls e.g. for energy
@@ -237,5 +236,3 @@ test_energy_forces_virial(hydrogen, MyType())
 ```
 
 *It is recommended that you use the test functions to test that your implementation supports the API fully!*
-
-

--- a/docs/src/interface-definition.md
+++ b/docs/src/interface-definition.md
@@ -221,7 +221,9 @@ using AtomsCalculators.AtomsCalculatorsTesting
 hydrogen = isolated_system([
     :H => [0, 0, 0.]u"Å",
     :H => [0, 0, 1.]u"Å"
-])test_energy_forces(sys, calculator; rtol=1e8, kwargs...)nergy(hydrogen, MyType())
+])
+
+test_potential_energy(hydrogen, MyType())
 test_forces(hydrogen, MyType())
 test_virial(hydrogen, MyType())
 

--- a/src/submodules/AtomsCalculatorsTesting.jl
+++ b/src/submodules/AtomsCalculatorsTesting.jl
@@ -16,7 +16,7 @@ export test_energy_forces_virial
     test_forces(sys, calculator; force_eltype::AbstractVector=default_force_eltype, rtol=1e8, kwargs...)
 
 Test your calculator for AtomsCalculators interface. Passing test means that your
-forces calculation implements the whole interface.
+forces calculation implementation works correctly.
 
 To use this function create a `AtomsBase` system `sys` and a `calculator` for your
 own calculator. Test function will then call the interface and performs checks
@@ -58,9 +58,7 @@ function test_forces(sys, calculator; force_eltype=nothing, rtol=1e8, kwargs...)
         end
         fc = AtomsCalculators.calculate(AtomsCalculators.Forces(), sys, calculator; kwargs...)
         @test isa(fc, NamedTuple)
-        @test haskey(fc, :forces)
-        @test all( f .- fc[:forces] ) do Δf  # f ≈ fc[:forces]
-            isapprox( ustrip.( zero(ftype) ), ustrip.(Δf); rtol=rtol)
+        @test haskey(fc, :forces)implements the whole interfaceftype) ), ustrip.(Δf); rtol=rtol)
         end
     end
 end
@@ -70,7 +68,7 @@ end
     test_potential_energy(sys, calculator; rtol=1e8, kwargs...)
 
 Test your calculator for AtomsCalculators interface. Passing test means that your
-potential energy calculation implements the whole interface.
+potential energy calculation implementation works correctly.
 
 To use this function create an `AtomsBase` system `sys` and a `calculator` for your
 own calculator. Test function will then call the interface and performs checks
@@ -100,7 +98,7 @@ end
     test_virial(sys, calculator; kwargs...)
 
 Test your calculator for AtomsCalculators interface. Passing test means that your
-virial calculation implements the whole interface.
+virial calculation implementation works correctly.
 
 To use this function create an `AtomsBase` system `sys` and a `calculator` for your
 own calculator. Test function will then call the interface and performs checks
@@ -133,7 +131,7 @@ end
     test_energy_forces(sys, calculator; force_eltype=nothing, rtol=1e8, kwargs...)
 
 Test your calculator for AtomsCalculators interface. Passing test means that your
-forces calculation implements the whole interface.
+calculator implements energy and forces interfaces correctly.
 
 To use this function create a `AtomsBase` system `sys` and a `calculator` for your
 own calculator. Test function will then call the interface and performs checks
@@ -177,7 +175,7 @@ end
     test_energy_forces_virial(sys, calculator; force_eltype=nothing, rtol=1e8, kwargs...)
 
 Test your calculator for AtomsCalculators interface. Passing test means that your
-forces calculation implements the whole interface.
+calculator implements energy, forces and virial interfaces correctly.
 
 To use this function create a `AtomsBase` system `sys` and a `calculator` for your
 own calculator. Test function will then call the interface and performs checks

--- a/src/submodules/AtomsCalculatorsTesting.jl
+++ b/src/submodules/AtomsCalculatorsTesting.jl
@@ -58,7 +58,9 @@ function test_forces(sys, calculator; force_eltype=nothing, rtol=1e8, kwargs...)
         end
         fc = AtomsCalculators.calculate(AtomsCalculators.Forces(), sys, calculator; kwargs...)
         @test isa(fc, NamedTuple)
-        @test haskey(fc, :forces)implements the whole interfaceftype) ), ustrip.(Δf); rtol=rtol)
+        @test haskey(fc, :forces)
+        @test all( f .- fc[:forces] ) do Δf  # f ≈ fc[:forces]
+            isapprox( ustrip.( zero(ftype) ), ustrip.(Δf); rtol=rtol)
         end
     end
 end

--- a/src/submodules/AtomsCalculatorsTesting.jl
+++ b/src/submodules/AtomsCalculatorsTesting.jl
@@ -31,8 +31,8 @@ function test_forces(sys, calculator; force_eltype=nothing, kwargs...)
             AtomsCalculators.promote_force_type(sys, calculator)
         )
         f = AtomsCalculators.forces(sys, calculator; kwargs...)
-        @test typeof(f) <: AbstractVector
-        @test eltype(f) <: AbstractVector
+        @test typeof(f) == typeof(AtomsCalculators.zero_forces(sys,calculator))
+        @test eltype(f) == ftype
         @test length(f) == length(sys)
         T = (eltype ∘ eltype)( f )
         f_matrix = reinterpret(reshape, T, f)
@@ -46,6 +46,7 @@ function test_forces(sys, calculator; force_eltype=nothing, kwargs...)
         f_nonallocating = zeros(ftype, length(sys))
         AtomsCalculators.forces!(f_nonallocating, sys, calculator; kwargs...)
         @test all( f_nonallocating .≈ f  )
+        fill!(f_nonallocating, zero(ftype)) # set f array to zeros
         AtomsCalculators.forces!(f_nonallocating, sys, calculator; dummy_kword659254=1, kwargs...)
         @test all( f_nonallocating .≈ f  )
         fc = AtomsCalculators.calculate(AtomsCalculators.Forces(), sys, calculator; kwargs...)

--- a/src/submodules/AtomsCalculatorsTesting.jl
+++ b/src/submodules/AtomsCalculatorsTesting.jl
@@ -16,7 +16,7 @@ export test_energy_forces_virial
     test_forces(sys, calculator; force_eltype::AbstractVector=default_force_eltype, rtol=1e8, kwargs...)
 
 Test your calculator for AtomsCalculators interface. Passing test means that your
-forces calculation.
+forces calculation implements the whole interface.
 
 To use this function create a `AtomsBase` system `sys` and a `calculator` for your
 own calculator. Test function will then call the interface and performs checks
@@ -70,7 +70,7 @@ end
     test_potential_energy(sys, calculator; rtol=1e8, kwargs...)
 
 Test your calculator for AtomsCalculators interface. Passing test means that your
-potential energy calculation.
+potential energy calculation implements the whole interface.
 
 To use this function create an `AtomsBase` system `sys` and a `calculator` for your
 own calculator. Test function will then call the interface and performs checks
@@ -100,7 +100,7 @@ end
     test_virial(sys, calculator; kwargs...)
 
 Test your calculator for AtomsCalculators interface. Passing test means that your
-virial calculation.
+virial calculation implements the whole interface.
 
 To use this function create an `AtomsBase` system `sys` and a `calculator` for your
 own calculator. Test function will then call the interface and performs checks
@@ -133,7 +133,7 @@ end
     test_energy_forces(sys, calculator; force_eltype=nothing, rtol=1e8, kwargs...)
 
 Test your calculator for AtomsCalculators interface. Passing test means that your
-forces calculation.
+forces calculation implements the whole interface.
 
 To use this function create a `AtomsBase` system `sys` and a `calculator` for your
 own calculator. Test function will then call the interface and performs checks
@@ -177,7 +177,7 @@ end
     test_energy_forces_virial(sys, calculator; force_eltype=nothing, rtol=1e8, kwargs...)
 
 Test your calculator for AtomsCalculators interface. Passing test means that your
-forces calculation.
+forces calculation implements the whole interface.
 
 To use this function create a `AtomsBase` system `sys` and a `calculator` for your
 own calculator. Test function will then call the interface and performs checks

--- a/src/submodules/AtomsCalculatorsTesting.jl
+++ b/src/submodules/AtomsCalculatorsTesting.jl
@@ -52,9 +52,8 @@ function test_forces(sys, calculator; force_eltype=nothing, rtol=1e8, kwargs...)
         @test all( f_nonallocating .- f  ) do Δf # f_nonallocating ≈ f
             isapprox( ustrip.( zero(ftype) ), ustrip.(Δf); rtol=rtol)
         end
-        fill!(f_nonallocating, zero(ftype)) # set f array to zeros
         AtomsCalculators.forces!(f_nonallocating, sys, calculator; dummy_kword659254=1, kwargs...)
-        @test all( f_nonallocating .- f  ) do Δf # f_nonallocating ≈ f
+        @test all( f_nonallocating .- 2f  ) do Δf # non-allocating is additive and called twice
             isapprox( ustrip.( zero(ftype) ), ustrip.(Δf); rtol=rtol)
         end
         fc = AtomsCalculators.calculate(AtomsCalculators.Forces(), sys, calculator; kwargs...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -210,7 +210,7 @@ function generate_nonallocating_forces(calc_type)
     q = quote
             function AtomsCalculators.forces!(F, system, calculator::$calc_type; kwargs...)
             @assert length(F) == length(system)
-            F .= AtomsCalculators.forces(system, calculator; kwargs...)
+            F .+= AtomsCalculators.forces(system, calculator; kwargs...)
             return F
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,7 +48,8 @@ using AtomsCalculators.AtomsCalculatorsTesting
     
         # add your own definition
         for i in eachindex(f)
-            f[i] = zero(AtomsCalculators.promote_force_type(system, calculator))
+            # forces! adds to the force array
+            f[i] += zero(AtomsCalculators.promote_force_type(system, calculator))
         end
     
         return f

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -101,9 +101,7 @@ using AtomsCalculators.AtomsCalculatorsTesting
     :H => [0, 0, 1.]u"Å"
     ])
 
-    test_potential_energy(hydrogen, MyType())
-    test_forces(hydrogen, MyType())
-    test_virial(hydrogen, MyType())
+    test_energy_forces_virial(hydrogen, MyType())
     test_forces(hydrogen, MyOtherType())
     
     test_potential_energy(hydrogen, MyTypeC())


### PR DESCRIPTION
This PR will solve couple of issues with testing and add combined testing functions that allow testing everything with a one call.

1.  non-allocating force call `forces!` takes in an array where forces are saved. It can be overwritten or added. It was not defined which one it should be. Now addition is defined and also tested.
2. Combination calls `energy_forces` and `energy_forces_virial` where not tested with test functions. This has now been updated with new functions `test_energy_forces` and test `energy_forces_virial`. The new function include the corresponding individual tests in them, so you should use them over the individual calls.
3. Added relative tolerance keyword for testing functions. This is needed, if there are different implementations to e.g. allocating and non-allocating forces. For consistency the keyword is implemented on all the calls.

With this the original version (v0.1) of AtomsCalculators should be complete and we can start to implement new functionality (#12)  to AtomsCalculators.

Couple of notes:
- We need to write more documentation. But this can be postponed untill we have added the new functionality
- The plan is to tag this to v0.1.2 and then have the new features in for v0.2

Could we get couple of fast approvals to get this one done fast, so that we can move forward to new funcitonality @cortner, @mfherbst, @rkurchin @jgreener64 

edit. updated 3. point on the descriptions