### PR TITLE
Fix a bug in the macro

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -122,9 +122,9 @@ function determine_type_calculation(expr)
         )
     elseif type_of_calculation == :calculate # calculator interface -> find calc type too
         # Need to have definition of AtomsCalculators.Energy() etc.
-        if expr.args[1].args[3].args[1].args[2].value in [:Energy, :Forces, :Virial]
+        if expr.args[1].args[3].args[end].args[end].value in [:Energy, :Forces, :Virial]
             return (;
-                :type => expr.args[1].args[3].args[1].args[2].value,
+                :type => expr.args[1].args[3].args[end].args[end].value,
                 :calculator => true
             )
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -140,7 +140,7 @@ end
     end
     
     AtomsCalculators.@generate_interface function AtomsCalculators.calculate(
-            ::AtomsCalculators.Virial,
+            v::AtomsCalculators.Virial,
             system, calculator::LowLevelCalculator,
             parameters=nothing, state=nothing;
             kwargs...)


### PR DESCRIPTION
## Description of input that causes the bug

Using following definition causes the bug

```julia
AtomsCalculators.@generate_interface function AtomsCalculators.calculate(
       e::AtomsCalculators.Energy, 
       sys, 
       calc::MyType, 
       pr=nothing, 
       st=nothing; 
       kwargs...
 )
    nothing
end
```

This definition however works

```julia
AtomsCalculators.@generate_interface function AtomsCalculators.calculate(
       ::AtomsCalculators.Energy,   # note removal of e from this line
       sys, 
       calc::MyType, 
       pr=nothing, 
       st=nothing; 
       kwargs...
 )
    nothing
end
```

## The cause of the bug

The bug can be inspected by calling

```julia
expr = Meta.parse("function AtomsCalculators.calculate(
       e::AtomsCalculators.Energy, 
       sys, 
       calc::MyType, 
       pr=nothing, 
       st=nothing; 
       kwargs...
 )
    nothing
end")
```

After which you get the bug by calling

```julia
expr.args[1].args[3].args[1].args[2].value  # Should return :Energy, but gives error
```

To get to the root of the error you can call

```julia
julia> expr.args[1].args[3].args
2-element Vector{Any}:
 :e
 :(AtomsCalculators.Energy)
```

Comparing that to the working case

```julia
working_expr = Meta.parse("function AtomsCalculators.calculate(
       ::AtomsCalculators.Energy, 
       sys, 
       calc::MyType, 
       pr=nothing, 
       st=nothing; 
       kwargs...
 )
    nothing
end")
```

```julia
julia> working_expr.args[1].args[3].args
1-element Vector{Any}:
 :(AtomsCalculators.Energy)
```

## Solution

Based on the above, the type of calculation is always on the last element of `expr.args[1].args[3].args`.
Thus using following call solves the bug and works for all the cases

```julia
expr.args[1].args[3].args[end].args[end].value  # Should return :Energy or calculation type in general
```

I changed the index for the last argument as well. It should read `AtomsCalculators.Energy`, where `AtomsCalculators` is the first index and `Energy` or calculation type the last index (2nd in practice). This is just to be safe for the future.

I also added (altered) a test to verify that all use cases are now tested.

## Severity of the bug

This bug has been in AtomsCalculators from the beginning and not been encountered before, so I don't expect this having been causing issues.

The only use case where this could be an issue and where it was discovered is, when you have a wrapper calculator and you want to have specific calls for it. 