### PR TITLE
Raplace the macro with a function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,14 @@ version = "0.2.1"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 AtomsBase = "0.3"
+InteractiveUtils = "1.6"
 StaticArrays = "1"
 Test = "1"
 Unitful = "1"

--- a/src/AtomsCalculators.jl
+++ b/src/AtomsCalculators.jl
@@ -5,6 +5,8 @@ using AtomsBase
 using StaticArrays
 using Unitful
 
+using InteractiveUtils: methodswith
+
 include("interface.jl")
 include("utils.jl")
 include("submodules/Testing.jl")

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -123,12 +123,8 @@ set_parameters!(calc, ps) = calc
 `energy_forces(system, calculator; kwargs...) -> NamedTuple`
 """
 function energy_forces(system, calculator; kwargs...)
-    e = potential_energy(system, calculator; kwargs...)
-    f = forces(system, calculator; kwargs...)
-    return (;
-        :energy => e,
-        :forces => f
-    )
+    ef = calculate((Energy(), Forces()), system, calculator; kwargs...)
+    return ef
 end 
 
 """
@@ -148,11 +144,12 @@ end
 """
 function energy_forces_virial(system, calculator; kwargs...)
     ef = energy_forces(system, calculator; kwargs...)
-    v = virial(system, calculator; kwargs...)
-    return (;
-        :energy => ef[:energy],
-        :forces => ef[:forces],
-        :virial => v
+    st = haskey(ef, :state) ? ef[:state] : nothing
+    v = calculate( Virial(), system, calculator, nothing, st; kwargs...)
+    return (
+        energy = ef.energy,
+        forces = ef.forces,
+        virial = v.virial
     )
 end 
 

--- a/src/submodules/Testing.jl
+++ b/src/submodules/Testing.jl
@@ -172,11 +172,19 @@ function test_energy_forces(sys, calculator; force_eltype=nothing, rtol=1e8, kwa
         e0 = AtomsCalculators.potential_energy(sys, calculator; kwargs...)
         f0 = AtomsCalculators.forces(sys, calculator; kwargs...)
         res = AtomsCalculators.energy_forces(sys, calculator; kwargs...)
+        calc_type = (AtomsCalculators.Energy(), AtomsCalculators.Forces())
+        cres = AtomsCalculators.calculate(calc_type, sys, calculator; kwargs...)
         @test isa(res, NamedTuple)
         @test haskey(res, :energy)
         @test haskey(res, :forces)
+        @test haskey(cres, :energy)
+        @test haskey(cres, :forces)
         @test e0 ≈ res[:energy] rtol=rtol
+        @test e0 ≈ cres[:energy] rtol=rtol
         @test all( f0 .- res[:forces]  ) do Δf
+            isapprox( ustrip.( zero(Δf) ), ustrip.(Δf); rtol=rtol)
+        end
+        @test all( f0 .- cres[:forces]  ) do Δf
             isapprox( ustrip.( zero(Δf) ), ustrip.(Δf); rtol=rtol)
         end
         f1 = AtomsCalculators.zero_forces(sys, calculator)
@@ -217,15 +225,25 @@ function test_energy_forces_virial(sys, calculator; force_eltype=nothing, rtol=1
         f0 = AtomsCalculators.forces(sys, calculator; kwargs...)
         v0 = AtomsCalculators.virial(sys, calculator; kwargs...)
         res = AtomsCalculators.energy_forces_virial(sys, calculator; kwargs...)
+        calc_type = (AtomsCalculators.Energy(), AtomsCalculators.Forces(), AtomsCalculators.Virial())
+        cres = AtomsCalculators.calculate(calc_type, sys, calculator; kwargs...)
         @test isa(res, NamedTuple)
         @test haskey(res, :energy)
         @test haskey(res, :forces)
         @test haskey(res, :virial)
+        @test haskey(cres, :energy)
+        @test haskey(cres, :forces)
+        @test haskey(cres, :virial)
         @test e0 ≈ res[:energy] rtol=rtol
+        @test e0 ≈ cres[:energy] rtol=rtol
         @test all( f0 .- res[:forces]  ) do Δf
             isapprox( ustrip.( zero(Δf) ), ustrip.(Δf); rtol=rtol)
         end
+        @test all( f0 .- cres[:forces]  ) do Δf
+            isapprox( ustrip.( zero(Δf) ), ustrip.(Δf); rtol=rtol)
+        end
         @test all( isapprox(v0, res[:virial]; rtol=rtol) )
+        @test all( isapprox(v0, cres[:virial]; rtol=rtol) )
 
         f1 = AtomsCalculators.zero_forces(sys, calculator)
         res2 = AtomsCalculators.energy_forces_virial!(f1, sys, calculator; kwargs...)

--- a/test/interface_generation_tests.jl
+++ b/test/interface_generation_tests.jl
@@ -64,7 +64,7 @@ using AtomsCalculators.Testing
         test_forces(hydrogen, MyCalc4())
     end
 
-    @testset "forces" begin
+    @testset "calculate forces" begin
         struct MyCalc5 <: MyCalc end
         function AtomsCalculators.calculate(
                 ::AtomsCalculators.Forces,
@@ -148,6 +148,41 @@ using AtomsCalculators.Testing
         end
         AtomsCalculators.generate_missing_interface(MyCalc11)
         test_energy_forces_virial(hydrogen, MyCalc11())
+    end
+
+    @testset "calculate energy and energy_forces_virial" begin
+        struct MyCalc12 <: MyCalc end
+        function AtomsCalculators.energy_forces_virial(system, calculator::MyCalc12; kwargs...)
+            f = AtomsCalculators.zero_forces(system, calculator)
+            v = zeros(3,3) * u"hartree"
+            return (energy=0.0u"hartree", forces=f, virial=v)
+        end
+        function AtomsCalculators.calculate(
+            ::AtomsCalculators.Energy,
+            system, calculator::MyCalc12,
+            parameters=nothing, state=nothing;
+            kwargs...)
+            return (; :energy => 0.0u"hartree", :state => nothing)
+        end
+        AtomsCalculators.generate_missing_interface(MyCalc12)
+        test_energy_forces_virial(hydrogen, MyCalc12())
+    end
+
+    @testset "calculate forces and energy_forces" begin
+        struct MyCalc13 <: MyCalc end
+        function AtomsCalculators.energy_forces(system, calculator::MyCalc13; kwargs...)
+            f = AtomsCalculators.zero_forces(system, calculator)
+            return (energy=0.0u"hartree", forces=f)
+        end
+        function AtomsCalculators.calculate(
+            ::AtomsCalculators.Forces,
+            system, calculator::MyCalc13,
+            parameters=nothing, state=nothing;
+            kwargs...)
+        return (; :forces => AtomsCalculators.zero_forces(system, calculator), :state => nothing)
+    end
+        AtomsCalculators.generate_missing_interface(MyCalc13)
+        test_energy_forces(hydrogen, MyCalc13())
     end
 
 end

--- a/test/interface_generation_tests.jl
+++ b/test/interface_generation_tests.jl
@@ -24,7 +24,7 @@ using AtomsCalculators.Testing
         function AtomsCalculators.potential_energy(system, calculator::MyCalc1; kwargs...)
             return 0.0u"hartree"
         end 
-        AtomsCalculators.generate_missing_interface(MyCalc1)
+        AtomsCalculators.complete_interface(MyCalc1)
         test_potential_energy(hydrogen, MyCalc1())
     end
 
@@ -37,7 +37,7 @@ using AtomsCalculators.Testing
             kwargs...)
             return (; :energy => 0.0u"hartree", :state => nothing)
         end
-        AtomsCalculators.generate_missing_interface(MyCalc2)
+        AtomsCalculators.complete_interface(MyCalc2)
         test_potential_energy(hydrogen, MyCalc2())
     end
 
@@ -46,7 +46,7 @@ using AtomsCalculators.Testing
         function AtomsCalculators.forces(system, calculator::MyCalc3; kwargs...)
             return AtomsCalculators.zero_forces(system, calculator)
         end
-        AtomsCalculators.generate_missing_interface(MyCalc3)
+        AtomsCalculators.complete_interface(MyCalc3)
         test_forces(hydrogen, MyCalc3())
     end
 
@@ -60,7 +60,7 @@ using AtomsCalculators.Testing
             end
             return f
         end
-        AtomsCalculators.generate_missing_interface(MyCalc4)
+        AtomsCalculators.complete_interface(MyCalc4)
         test_forces(hydrogen, MyCalc4())
     end
 
@@ -73,7 +73,7 @@ using AtomsCalculators.Testing
                 kwargs...)
             return (; :forces => AtomsCalculators.zero_forces(system, calculator), :state => nothing)
         end
-        AtomsCalculators.generate_missing_interface(MyCalc5)
+        AtomsCalculators.complete_interface(MyCalc5)
         test_forces(hydrogen, MyCalc5())
     end
 
@@ -83,7 +83,7 @@ using AtomsCalculators.Testing
         function AtomsCalculators.virial(system, calculator::MyCalc6; kwargs...)
             return zeros(3,3) * u"hartree"
         end 
-        AtomsCalculators.generate_missing_interface(MyCalc6)
+        AtomsCalculators.complete_interface(MyCalc6)
         test_virial(hydrogen, MyCalc6())
     end
 
@@ -96,7 +96,7 @@ using AtomsCalculators.Testing
                 kwargs...)
             return (; :virial => zeros(3,3) * u"hartree", :state => nothing)
         end
-        AtomsCalculators.generate_missing_interface(MyCalc7)
+        AtomsCalculators.complete_interface(MyCalc7)
         test_virial(hydrogen, MyCalc7())
     end
 
@@ -106,7 +106,7 @@ using AtomsCalculators.Testing
             f = AtomsCalculators.zero_forces(system, calculator)
             return (energy=0.0u"hartree", forces=f)
         end
-        AtomsCalculators.generate_missing_interface(MyCalc8)
+        AtomsCalculators.complete_interface(MyCalc8)
         test_energy_forces(hydrogen, MyCalc8())
     end
 
@@ -117,7 +117,7 @@ using AtomsCalculators.Testing
             v = zeros(3,3) * u"hartree"
             return (energy=0.0u"hartree", forces=f, virial=v)
         end
-        AtomsCalculators.generate_missing_interface(MyCalc9)
+        AtomsCalculators.complete_interface(MyCalc9)
         test_energy_forces_virial(hydrogen, MyCalc9())
     end
 
@@ -131,7 +131,7 @@ using AtomsCalculators.Testing
             end
             return (energy=0.0u"hartree", forces=f)
         end
-        AtomsCalculators.generate_missing_interface(MyCalc10)
+        AtomsCalculators.complete_interface(MyCalc10)
         test_potential_energy(hydrogen, MyCalc10())
     end
 
@@ -146,7 +146,7 @@ using AtomsCalculators.Testing
             v = zeros(3,3) * u"hartree"
             return (energy=0.0u"hartree", forces=f, virial=v)
         end
-        AtomsCalculators.generate_missing_interface(MyCalc11)
+        AtomsCalculators.complete_interface(MyCalc11)
         test_energy_forces_virial(hydrogen, MyCalc11())
     end
 
@@ -164,7 +164,7 @@ using AtomsCalculators.Testing
             kwargs...)
             return (; :energy => 0.0u"hartree", :state => nothing)
         end
-        AtomsCalculators.generate_missing_interface(MyCalc12)
+        AtomsCalculators.complete_interface(MyCalc12)
         test_energy_forces_virial(hydrogen, MyCalc12())
     end
 
@@ -181,7 +181,7 @@ using AtomsCalculators.Testing
             kwargs...)
         return (; :forces => AtomsCalculators.zero_forces(system, calculator), :state => nothing)
     end
-        AtomsCalculators.generate_missing_interface(MyCalc13)
+        AtomsCalculators.complete_interface(MyCalc13)
         test_energy_forces(hydrogen, MyCalc13())
     end
 

--- a/test/interface_generation_tests.jl
+++ b/test/interface_generation_tests.jl
@@ -1,0 +1,154 @@
+using AtomsBase
+using AtomsCalculators
+using Test
+using Unitful
+using UnitfulAtomic
+
+using AtomsCalculators.Testing
+
+@testset "Interface Generation" begin
+    abstract type MyCalc end
+    function AtomsCalculators.energy_unit(::MyCalc)
+        u"hartree"
+    end 
+    function AtomsCalculators.length_unit(::MyCalc)
+        u"bohr"
+    end
+    hydrogen = isolated_system([
+            :H => [0, 0, 0.]u"Å",
+            :H => [0, 0, 1.]u"Å"
+        ])
+    
+    @testset "potential energy" begin
+        struct MyCalc1 <: MyCalc end
+        function AtomsCalculators.potential_energy(system, calculator::MyCalc1; kwargs...)
+            return 0.0u"hartree"
+        end 
+        AtomsCalculators.generate_missing_interface(MyCalc1)
+        test_potential_energy(hydrogen, MyCalc1())
+    end
+
+    @testset "calculate energy" begin
+        struct MyCalc2 <: MyCalc end
+        function AtomsCalculators.calculate(
+            ::AtomsCalculators.Energy,
+            system, calculator::MyCalc2,
+            parameters=nothing, state=nothing;
+            kwargs...)
+            return (; :energy => 0.0u"hartree", :state => nothing)
+        end
+        AtomsCalculators.generate_missing_interface(MyCalc2)
+        test_potential_energy(hydrogen, MyCalc2())
+    end
+
+    @testset "forces" begin
+        struct MyCalc3 <: MyCalc end
+        function AtomsCalculators.forces(system, calculator::MyCalc3; kwargs...)
+            return AtomsCalculators.zero_forces(system, calculator)
+        end
+        AtomsCalculators.generate_missing_interface(MyCalc3)
+        test_forces(hydrogen, MyCalc3())
+    end
+
+    @testset "forces!" begin
+        struct MyCalc4 <: MyCalc end
+        function AtomsCalculators.forces!(f::AbstractVector, system, calculator::MyCalc4; kwargs...)
+            @assert length(f) == length(system)
+            for i in eachindex(f)
+                # forces! adds to the force array
+                f[i] += zero(AtomsCalculators.promote_force_type(system, calculator))
+            end
+            return f
+        end
+        AtomsCalculators.generate_missing_interface(MyCalc4)
+        test_forces(hydrogen, MyCalc4())
+    end
+
+    @testset "forces" begin
+        struct MyCalc5 <: MyCalc end
+        function AtomsCalculators.calculate(
+                ::AtomsCalculators.Forces,
+                system, calculator::MyCalc5,
+                parameters=nothing, state=nothing;
+                kwargs...)
+            return (; :forces => AtomsCalculators.zero_forces(system, calculator), :state => nothing)
+        end
+        AtomsCalculators.generate_missing_interface(MyCalc5)
+        test_forces(hydrogen, MyCalc5())
+    end
+
+
+    @testset "virial" begin
+        struct MyCalc6 <: MyCalc end
+        function AtomsCalculators.virial(system, calculator::MyCalc6; kwargs...)
+            return zeros(3,3) * u"hartree"
+        end 
+        AtomsCalculators.generate_missing_interface(MyCalc6)
+        test_virial(hydrogen, MyCalc6())
+    end
+
+    @testset "calculate virial" begin
+        struct MyCalc7 <: MyCalc end
+        function AtomsCalculators.calculate(
+                v::AtomsCalculators.Virial,
+                system, calculator::MyCalc7,
+                parameters=nothing, state=nothing;
+                kwargs...)
+            return (; :virial => zeros(3,3) * u"hartree", :state => nothing)
+        end
+        AtomsCalculators.generate_missing_interface(MyCalc7)
+        test_virial(hydrogen, MyCalc7())
+    end
+
+    @testset "energy_forces" begin
+        struct MyCalc8 <: MyCalc end
+        function AtomsCalculators.energy_forces(system, calculator::MyCalc8; kwargs...)
+            f = AtomsCalculators.zero_forces(system, calculator)
+            return (energy=0.0u"hartree", forces=f)
+        end
+        AtomsCalculators.generate_missing_interface(MyCalc8)
+        test_energy_forces(hydrogen, MyCalc8())
+    end
+
+    @testset "energy_forces_virial" begin
+        struct MyCalc9 <: MyCalc end
+        function AtomsCalculators.energy_forces_virial(system, calculator::MyCalc9; kwargs...)
+            f = AtomsCalculators.zero_forces(system, calculator)
+            v = zeros(3,3) * u"hartree"
+            return (energy=0.0u"hartree", forces=f, virial=v)
+        end
+        AtomsCalculators.generate_missing_interface(MyCalc9)
+        test_energy_forces_virial(hydrogen, MyCalc9())
+    end
+
+    @testset "energy_forces!" begin
+        struct MyCalc10 <: MyCalc end
+        function AtomsCalculators.energy_forces!(f::AbstractVector, system, calculator::MyCalc10; kwargs...)
+            @assert length(f) == length(system)
+            for i in eachindex(f)
+                # forces! adds to the force array
+                f[i] += zero(AtomsCalculators.promote_force_type(system, calculator))
+            end
+            return (energy=0.0u"hartree", forces=f)
+        end
+        AtomsCalculators.generate_missing_interface(MyCalc10)
+        test_potential_energy(hydrogen, MyCalc10())
+    end
+
+    @testset "energy_forces_virial!" begin
+        struct MyCalc11 <: MyCalc end
+        function AtomsCalculators.energy_forces_virial!(f::AbstractVector, system, calculator::MyCalc11; kwargs...)
+            @assert length(f) == length(system)
+            for i in eachindex(f)
+                # forces! adds to the force array
+                f[i] += zero(AtomsCalculators.promote_force_type(system, calculator))
+            end
+            v = zeros(3,3) * u"hartree"
+            return (energy=0.0u"hartree", forces=f, virial=v)
+        end
+        AtomsCalculators.generate_missing_interface(MyCalc11)
+        test_energy_forces_virial(hydrogen, MyCalc11())
+    end
+
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,6 +79,30 @@ using AtomsCalculators.Testing
         Base.remove_linenums!(expr_high_level_virial).args[1])[:type] == :virial
 end
 
+
+@testset "New Macro" begin
+    struct MyCalc end
+    function AtomsCalculators.potential_energy(system, calculator::MyCalc; kwargs...)
+        return 0.0u"hartree"
+    end
+    function AtomsCalculators.energy_unit(::MyCalc)
+        u"hartree"
+    end 
+    function AtomsCalculators.length_unit(::MyCalc)
+        u"bohr"
+    end 
+    AtomsCalculators.generate_missing(MyCalc)
+    stats = AtomsCalculators.implementation_status(MyCalc)
+    @test stats[:calculate_energy]
+    hydrogen = isolated_system([
+        :H => [0, 0, 0.]u"Å",
+        :H => [0, 0, 1.]u"Å"
+    ])
+
+    test_potential_energy(hydrogen, MyCalc())
+end
+
+
 @testset "High-level calculator interface" begin
     struct HighLevelCalculator end
     struct HighLevelCalculatorAllocating end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,8 @@ using UnitfulAtomic
 using AtomsCalculators.Testing
 
 
+include("interface_generation_tests.jl")
+
 @testset "Parsing macro" begin
     expr_low_level_energy = quote
         function AtomsCalculators.calculate(::AtomsCalculators.Energy, system::AbstractSystem,
@@ -80,27 +82,6 @@ using AtomsCalculators.Testing
 end
 
 
-@testset "New Macro" begin
-    struct MyCalc end
-    function AtomsCalculators.potential_energy(system, calculator::MyCalc; kwargs...)
-        return 0.0u"hartree"
-    end
-    function AtomsCalculators.energy_unit(::MyCalc)
-        u"hartree"
-    end 
-    function AtomsCalculators.length_unit(::MyCalc)
-        u"bohr"
-    end 
-    AtomsCalculators.generate_missing(MyCalc)
-    stats = AtomsCalculators.implementation_status(MyCalc)
-    @test stats[:calculate_energy]
-    hydrogen = isolated_system([
-        :H => [0, 0, 0.]u"Å",
-        :H => [0, 0, 1.]u"Å"
-    ])
-
-    test_potential_energy(hydrogen, MyCalc())
-end
 
 
 @testset "High-level calculator interface" begin


### PR DESCRIPTION
This PR will implement a new function called `AtomsCalculators.complete_interface` mean to replace the old macro.

The function works by checking what has been implemented for the given calculator and then implements the missing parts.

Here is in an example a complete energy interface

```julia
using AtomsCalculators
import AtomsCalculators: potential_energy
using Unitful
using UnitfulAtomic

struct MyCalc end

AtomsCalculators.energy_unit(::MyCalc) =  u"hartree"
AtomsCalculators.length_unit(::MyCalc) =  u"bohr"

function potential_energy(system, calculator::MyCalc; kwargs...)
       return 0.0u"hartree"
end 

AtomsCalculators.complete_interface(MyCalc)
```


You can also do this to implement all energy and force calls

```julia
using AtomsCalculators
import AtomsCalculators: energy_forces
using Unitful
using UnitfulAtomic

struct MyCalc end

AtomsCalculators.energy_unit(::MyCalc) =  u"hartree"
AtomsCalculators.length_unit(::MyCalc) =  u"bohr"

function energy_forces(system, calculator::MyCalc; kwargs...)
       f = AtomsCalculators.zero_forces(system, calculator)
        return (energy=0.0u"hartree", forces=f)
end 

AtomsCalculators.complete_interface(MyCalc)
```

In practice you can now just implement whatever and after that call `AtomsCalculators.complete_interface`, and you will have a complete interface.

The function is now also optimized in a way that it detects optimized calls, like `energy_forces` forms other optimized calls, like `calculate( (Energy(), Forces() ), sys, calc)` based on it.

The opposite also works, if there is an optimized `calculate( (Energy(), Forces() ), sys, calc)` call, then `energy_forces` call will use that.


### implementation_status helper function

There is a new helper function `implementation_status` that is also useful for problem cases. It basically checks what parts of interface have been implemented and what not

E.g.

```julia
using AtomsCalculators
import AtomsCalculators: energy_forces
using Unitful
using UnitfulAtomic

struct MyCalc end

AtomsCalculators.energy_unit(::MyCalc) =  u"hartree"
AtomsCalculators.length_unit(::MyCalc) =  u"bohr"

function energy_forces(system, calculator::MyCalc; kwargs...)
       f = AtomsCalculators.zero_forces(system, calculator)
       return (energy=0.0u"hartree", forces=f)
end 

AtomsCalculators.implementation_status(MyCalc)
```

returns

```julia
Dict{Symbol, Bool} with 11 entries:
  :energy_forces         => 1
  :virial                => 0
  :energy_forces_virial! => 0
  :calculate_virial      => 0
  :energy_forces_virial  => 0
  :calculate_forces      => 0
  :energy_forces!        => 0
  :forces                => 0
  :potential_energy      => 0
  :calculate_energy      => 0
  :forces!               => 0
```

This function is used by `complete_interface` function to determine what needs to be implented.`

## Discussion and comments

This should now implement all what was discussed in #26 and #27 (@rkurchin  and @mfherbst).

In my opinion this is a much better than the macro we use. And I propose we deprecate the macro in favor of this.

The new function should be very robust. It only needs that `AtomsCalculators` is in scope. After that is should be completely safe to call and it should not give out any errors (other than AtomsCalculators has not been defined). In fact you can call the function several times and it would not do anything extra. You can also call the function in a different module and it should still complete the interface.

Documentation page is still missing. I will add it, if we agree that this function is the way to go.

While the new function is much more simpler to use and less error prone, it is actually a lot more complicated that the old macro. This is a possible error source. But, I believe I managed to iron out the errors. The issue is that there are so many possible implementation combinations that it is not possible to test all of them. How ever, in practice only couple of all possibilities are used in practice. So this should be fine. 

 