### PR TITLE
Support Julia v1.11 public API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,14 @@ version = "0.2.1"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 AtomsBase = "0.3, 0.4"
+Compat = "4.12"
 StaticArrays = "1"
 Test = "1"
 Unitful = "1"

--- a/src/AtomsCalculators.jl
+++ b/src/AtomsCalculators.jl
@@ -2,8 +2,33 @@ module AtomsCalculators
 
 
 using AtomsBase: AbstractSystem
+using Compat: @compat
 using StaticArrays
 using Unitful
+
+@compat public Energy
+@compat public Forces
+@compat public Virial
+@compat public calculate
+@compat public energy_forces
+@compat public energy_forces!
+@compat public energy_forces_virial
+@compat public energy_forces_virial!
+@compat public energy_unit
+@compat public forces
+@compat public forces!
+@compat public get_parameters
+@compat public get_state
+@compat public length_unit
+@compat public potential_energy
+@compat public promote_force_type
+@compat public set_parameters!
+@compat public set_state!
+@compat public virial
+@compat public zero_energy
+@compat public zero_forces
+@compat public zero_virial
+
 
 include("interface.jl")
 include("utils.jl")


### PR DESCRIPTION
Julia v1.11 has a new `public` API that allow specifying non exported methods/structures to be part of the public API. This is very useful for AtomsCalculators, as the API is not exported at all.

Compatibility to older Julia versions is done with [Compat.jl](https://github.com/JuliaLang/Compat.jl)

With Julia v1.11 you can now call

```julia
using AtomsCalculators

names(AtomsCalculatos) # lists the whole API
```

This does not change any functionality with AtomsCalculators, so will merge once CI passes.